### PR TITLE
投稿編集機能+投稿削除機能実装

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -47,6 +47,8 @@ $sub2_color: #ffffff;
   margin-top: 40px;
   color: #5a5359;
   .microposts_mainview_name {
+    display: flex;
+    justify-content: space-between;
     margin-bottom: 16px;
     font-size: 24px;
     font-weight: bold;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :confirm, :back]
+  before_action :authenticate_user!, only: [:new, :edit, :confirm, :back]
+  before_action :ensure_correct_user, only: [:edit, :update, :destroy]
 
   def index
     @post = Post.all.limit(4).order(created_at: :desc)
@@ -41,6 +42,24 @@ class PostsController < ApplicationController
     end
   end
 
+  def edit
+    @post = Post.find(params[:id])
+  end
+
+  def update
+    @post = Post.find(params[:id])
+    @post.update(post_params)
+    redirect_to post_path(@post.id)
+    flash[:notice] = "投稿を編集しました。"
+  end
+
+  def destroy
+    @post = Post.find(params[:id])
+    @post.destroy
+    redirect_to posts_path
+    flash[:notice] = "投稿を削除しました。"
+  end
+
   def confirm
     @post = Post.new(post_params)
     session[:category_ids] = @post.category_ids
@@ -68,5 +87,13 @@ class PostsController < ApplicationController
                                  :station,
                                  :shop_name,
                                  category_ids: []).merge(user_id: current_user.id)
+  end
+
+  def ensure_correct_user
+    @post = Post.find_by(id: params[:id])
+    if @post.user.id != current_user.id
+      flash[:notice] = "投稿者ではないため権限がありません"
+      redirect_to posts_path
+    end
   end
 end

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -1,0 +1,44 @@
+.contents.contents_medium
+  .form
+    .form_title
+      | 投稿編集
+    = form_with model: @post, local: true, url: post_path(@post.id) do |f|
+      .form-group
+        = f.label :area, "エリア名"
+        = f.text_field :area, autofocus: true, class: "form-control", placeholder: "(例 千葉フォルニア"
+      .form-group
+        = f.label :station, "最寄駅"
+        = f.text_field :station,  autofocus: "off", class: "form-control", placeholder: "(例 東京駅"
+      .form-group
+        = f.label :place_name, "都道府県"
+        = f.select :place_name, Post.place_names.keys, {}, {class: 'place'}
+      .form-group
+        = image_tag(@post.post_photo.url) if @post.post_photo?
+        = f.label :post_photo, "写真"
+        = f.file_field :post_photo, autofocus: "off", class: "form-control photo_text"
+        = f.hidden_field :post_photo_cache
+      .form-group
+        = f.label :shop_name, "店名"
+        = f.text_field :shop_name, autofocus: true, class: "form-control", placeholder: "(例 xxライダーカフェ"
+      .form-group
+        = f.label :street_address, "住所"
+        = f.text_field :street_address, autofocus: "off", class: "form-control", placeholder: "(例 東京都中央区xxx町 1-1-1"
+      .form-group
+        = f.label :time, "営業時間"
+        = f.text_field :time, autofocus: "off", class: "form-control", placeholder: "(例 9:00 ~ 19:00"
+      .form-group
+        = f.label :regular_holiday, "定休日"
+        = f.text_field :regular_holiday, autofocus: "off", class: "form-control", placeholder: "(例 月曜日"
+      .form-group
+        = f.label :url, "URL"
+        = f.text_field :url, autofocus: "off", class: "form-control"
+      .form-group
+        = f.label :category, "カテゴリ", class: "item-tag"
+        = f.collection_check_boxes(:category_ids, Category.all, :id, :name, include_hidden: false) do |category|
+          .item_tag
+            = category.label do
+              = category.check_box
+              .item-span
+                span = category.text
+      div[style="text-align: center;"]
+        = f.submit "更新する", class: "btn-square"

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -19,6 +19,11 @@
         .microposts_mainview_info
           .microposts_mainview_name
             = @post.area
+            .microposts_mainview_span
+              - if user_signed_in?
+                - if current_user.id == @user.id
+                  span = link_to "投稿を編集する", edit_post_path(@post.id), class: "btn_main"
+                  span = link_to "投稿を削除する", post_path, method:"delete", class: "btn_main", data: { confirm: "本当に削除しますか？" }
           .microposts_mainview_good.inline
             = render "likes/like_count", post: @post
           .microposts_mainview_comments.inline

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: [:show, :edit, :update, :destroy]
-  resources :posts, only: [:new, :index, :create, :show] do
-    resources :reviews, only: [:new, :index, :create]
+  resources :posts, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
+    resources :reviews, only: [:index, :new, :create]
     resources :favorites, only: [:create, :destroy]
     resources :likes, only: [:create, :destroy]
     collection do

--- a/spec/system/post_spec.rb
+++ b/spec/system/post_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe "Posts", type: :system do
         visit post_path(posts.id)
       end
 
+      example "投稿削除ボタンが機能すること" do
+        click_on "投稿を削除する"
+        expect(page).to have_content "投稿を削除しました"
+      end
+
+      example "投稿編集ボタンが機能すること" do
+        click_on "投稿を編集する"
+        click_on "更新する"
+        expect(page).to have_content "投稿を編集しました"
+      end
+
       example "いいねボタンが表示されていること" do
         expect(page).to have_selector ".fa-thumbs-up"
       end


### PR DESCRIPTION
・投稿一覧ページ観光地名横にて投稿編集機能+投稿削除機能ボタンを実装
・投稿者本人のみ操作できるよう実装
・自身の投稿のみボタンを設置、他者の投稿には非表示
・非ログインの場合、新規登録画面にリダイレクト
・投稿削除ボタンタップ後は間違い防止の為、確認ダイヤログを実装